### PR TITLE
Fix langchain import compatibility

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,11 +11,11 @@ from pydantic import BaseModel, Field, ValidationError
 
 from langchain_chroma import Chroma
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import PyPDFLoader
-from langchain.chains import create_retrieval_chain
-from langchain.chains.combine_documents import create_stuff_documents_chain
-from langchain.chains.history_aware_retriever import create_history_aware_retriever
+from langchain_classic.chains import create_retrieval_chain
+from langchain_classic.chains.combine_documents import create_stuff_documents_chain
+from langchain_classic.chains.history_aware_retriever import create_history_aware_retriever
 from langchain_core.chat_history import BaseChatMessageHistory, InMemoryChatMessageHistory
 from langchain_core.output_parsers import StrOutputParser, PydanticOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder, PromptTemplate

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,10 @@
 fastapi
 uvicorn
-langchain>=0.3.0
+langchain>=1.0.0
+langchain-core>=1.1.0
 langchain-community>=0.3.0
+langchain-classic>=1.0.0
+langchain-text-splitters>=1.0.0
 langchain-chroma>=0.1.0
 langchain-google-genai>=1.0.0
 pypdf


### PR DESCRIPTION
## Summary
- update langchain imports to use the supported classic and text splitter packages
- add explicit langchain dependency pins required by the backend

## Testing
- GEMINI_API_KEY=placeholder python -m py_compile backend/main.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4caa03a0832e958406bf42010d22)