### PR TITLE
Improve chat UX with persistence and input counter

### DIFF
--- a/html_css_js_frontend/app.js
+++ b/html_css_js_frontend/app.js
@@ -1,6 +1,7 @@
 // ===== Configuration =====
 const API_BASE = document.querySelector('meta[name="api-base-url"]')?.content || 'http://localhost:8000';
 const SESSION_KEY = 'medassist-session-id';
+const CHAT_HISTORY_KEY = 'medassist-chat-history';
 
 // ===== State Management =====
 let sessionId = localStorage.getItem(SESSION_KEY) || generateSessionId();
@@ -22,7 +23,8 @@ const elements = {
   statusText: document.getElementById('statusText'),
   messageCountEl: document.getElementById('messageCount'),
   suggestedPrompts: document.getElementById('suggestedPrompts'),
-  chatContainer: document.getElementById('chatContainer')
+  chatContainer: document.getElementById('chatContainer'),
+  charCounter: document.getElementById('charCounter')
 };
 
 // ===== Utility Functions =====
@@ -51,6 +53,42 @@ function updateMessageCount() {
   if (elements.messageCountEl) {
     elements.messageCountEl.textContent = messageCount;
   }
+}
+
+
+function updateCharCounter() {
+  if (!elements.chatInput || !elements.charCounter) return;
+  const len = elements.chatInput.value.length;
+  elements.charCounter.textContent = `${len}/${MAX_QUERY_LENGTH}`;
+  elements.charCounter.classList.toggle('over-limit', len > MAX_QUERY_LENGTH);
+}
+
+function saveChatHistory() {
+  if (!elements.chatMessages) return;
+  localStorage.setItem(CHAT_HISTORY_KEY, elements.chatMessages.innerHTML);
+}
+
+function restoreChatHistory() {
+  const saved = localStorage.getItem(CHAT_HISTORY_KEY);
+  if (!saved || !elements.chatMessages) return;
+
+  elements.chatMessages.innerHTML = saved;
+  messageCount = elements.chatMessages.querySelectorAll('.message').length;
+  if (elements.messageCountEl) {
+    elements.messageCountEl.textContent = messageCount.toString();
+  }
+
+  elements.chatMessages.querySelectorAll('.references-toggle').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const content = toggle.parentElement?.querySelector('.references-content');
+      content?.classList.toggle('hidden');
+    });
+  });
+
+  if (messageCount > 0 && elements.suggestedPrompts) {
+    elements.suggestedPrompts.classList.add('hidden');
+  }
+  scrollToBottom();
 }
 
 function showToast(message, type = 'info') {
@@ -164,6 +202,7 @@ function appendMessage(role, content, sources = null, isTyping = false) {
   
   if (!isTyping) {
     updateMessageCount();
+    saveChatHistory();
   }
   
   return messageDiv;
@@ -302,6 +341,7 @@ function clearChat() {
     if (elements.suggestedPrompts) {
       elements.suggestedPrompts.classList.remove('hidden');
     }
+    localStorage.removeItem(CHAT_HISTORY_KEY);
     showToast('Chat cleared', 'success');
   }
 }
@@ -405,7 +445,10 @@ function handleKeyPress(e) {
 // ===== Event Listeners =====
 elements.btnSend.addEventListener('click', () => sendMessage(elements.chatInput.value));
 elements.chatInput.addEventListener('keydown', handleKeyPress);
-elements.chatInput.addEventListener('input', autoResizeTextarea);
+elements.chatInput.addEventListener('input', () => {
+  autoResizeTextarea();
+  updateCharCounter();
+});
 elements.btnClearChat.addEventListener('click', clearChat);
 elements.btnGeneratePDF.addEventListener('click', openPDFModal);
 elements.btnCloseModal.addEventListener('click', closePDFModal);
@@ -417,6 +460,7 @@ document.querySelectorAll('.chip').forEach(chip => {
     const prompt = chip.dataset.prompt;
     elements.chatInput.value = prompt;
     autoResizeTextarea();
+    updateCharCounter();
     elements.chatInput.focus();
   });
 });
@@ -427,6 +471,8 @@ elements.prescriptionModal.querySelector('.modal-overlay').addEventListener('cli
 document.addEventListener('DOMContentLoaded', () => {
   elements.chatInput.focus();
   updateStatus('Connected', true);
+  restoreChatHistory();
+  updateCharCounter();
   initializeHoverGuides();
 
   fetch(`${API_BASE}/`)

--- a/html_css_js_frontend/index.html
+++ b/html_css_js_frontend/index.html
@@ -207,7 +207,7 @@
                   Send
                 </button>
               </div>
-              <p class="input-hint">Press <kbd>Enter</kbd> to send • <kbd>Shift + Enter</kbd> for new line</p>
+              <p class="input-hint">Press <kbd>Enter</kbd> to send • <kbd>Shift + Enter</kbd> for new line <span id="charCounter" class="char-counter">0/2000</span></p>
             </div>
           </div>
         </section>

--- a/html_css_js_frontend/styles.css
+++ b/html_css_js_frontend/styles.css
@@ -993,3 +993,14 @@ kbd {
 .mt-2 { margin-top: 1rem; }
 .mb-1 { margin-bottom: 0.5rem; }
 .mb-2 { margin-bottom: 1rem; }
+
+.char-counter {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.char-counter.over-limit {
+  color: var(--danger);
+  font-weight: 600;
+}


### PR DESCRIPTION
### Motivation
- Reduce user friction by showing a live character counter so queries stay within the 2000-character limit.  
- Improve consultation continuity by persisting chat history across page reloads.  
- Preserve message-level functionality (message count and source toggles) when restoring history.  
- Ensure clearing the conversation also clears persisted state for privacy and consistency.  

### Description
- Added a live character counter UI near the chat input and styles for an over-limit visual state (`index.html`, `styles.css`).  
- Implemented `CHAT_HISTORY_KEY`, `saveChatHistory()`, `restoreChatHistory()`, and `updateCharCounter()` in the frontend logic and wired them into message append, input, chip-click, and DOM load flows (`app.js`).  
- Persisted chat HTML to `localStorage` after each message and re-bound reference-toggle handlers when restoring history to keep source view functionality.  
- Cleared persisted history when the user clears the chat and kept message-count updates in sync with restored content.  

### Testing
- Ran repository whitespace/style checks and basic repository integrity validation with no issues detected.  
- Verified the frontend behavior locally by reloading the page to confirm history restoration, character counter updates, and clearing behavior (automated unit tests are not present for the UI in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0429f3b5b8832ea6b0b3e20d6d9dd2)